### PR TITLE
Configure babel to transpile async/await syntax.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,6 @@
 {
+  "plugins": [
+    "transform-regenerator"
+  ],
   "presets": [ "es2015" ]
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "babel-eslint": "^7.2.3",
     "babel-plugin-external-helpers": "^6.18.0",
+    "babel-plugin-transform-regenerator": "^6.24.1",
     "babel-preset-es2015": "^6.18.0",
     "babel-register": "^6.18.0",
     "babelrc-rollup": "^3.0.0",


### PR DESCRIPTION
On modern browsers, I think this is not necessary; so we could also just
leave the async/await syntax for now, and transpile when we want to
release things with wider browser support. Same would count for all
transpilation, I guess.